### PR TITLE
display error messages which occured while generating html resume

### DIFF
--- a/src/bin/md2resume.coffee
+++ b/src/bin/md2resume.coffee
@@ -29,7 +29,7 @@ program
   # Make the output filename
   outputFileName = path.join sourceFileDir, sourceFileBasename + '.html'
 
-  input = fs.readFileSync sourceFile, 'utf8'  
+  input = fs.readFileSync sourceFile, 'utf8'
 
   # Need to write these files async
   if program.pdf
@@ -45,7 +45,10 @@ program
         console.log "Wrote pdf to: #{pdfOutputFileName}"
   else
     md2resume.generate input, { template: program.template }, (err, out) ->
+      if err?
+        return console.log err
+
       # Write the file contents
       fs.writeFile outputFileName, out, (err) ->
        console.log "Wrote html to: #{outputFileName}"
-  
+


### PR DESCRIPTION
I experienced some errors generating an html resume and noticed that it was failing silently. I added the same error handling(display error, exit) to match the pdf version.
