### PR TITLE
adjusts panel widths to avoid text overlap

### DIFF
--- a/assets/css/pdf.css
+++ b/assets/css/pdf.css
@@ -45,13 +45,13 @@ body.pdf {
     
     h3~p {
         float: left;
-        margin-left: 16%;
+        margin-left: 20%;
     }
     
     h3+p {
         margin-left: inherit;
         float: left;
-        width: 84%;
+        width: 80%;
     }
 
     blockquote {

--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -92,13 +92,13 @@
 
     h3~p {
         float: left;
-        margin-left: 16%;
+        margin-left: 20%;
     }
     
     h3+p {
         margin-left: inherit;
         float: left;
-        width: 84%;
+        width: 80%;
     }
     
     ul li {


### PR DESCRIPTION
**screenshot of my html/pdf output:**
![1](https://cloud.githubusercontent.com/assets/1312081/6431094/98cee4f2-bff2-11e4-95e7-0591d7d22d8a.png)
It's likely that someone else might use a large word like I did.  I adjusted the column widths slightly to hopefully avoid more of these problems in the future.  

**screenshot after this commit:**
![2](https://cloud.githubusercontent.com/assets/1312081/6431113/19a4f396-bff3-11e4-880a-d1ff285040cc.png)
