### PR TITLE
feat: debloat package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,14 +43,11 @@
     "clean-css": "^4.1.9",
     "commander": "^2.9.0",
     "html-minifier": "^3.5.8",
-    "html-pdf": "^2.0.1",
     "inliner": "^1.13.1",
     "less": "^2.6.1",
     "marked": "^0.3.12",
-    "meow": "^4.0.0",
     "mustache": "^2.2.1",
-    "nyc": "^11.4.1",
-    "read-pkg": "^3.0.0"
+    "nyc": "^11.4.1"
   },
   "devDependencies": {
     "chai": "^4.1.2",


### PR DESCRIPTION
Hi,

Thanks for developing this good project, which provides high-coverage tests.

I'm doing dynamic analysis on npm packages, and your project is one of my samples.

Through our dynamic analysis by running the test suites, we find that 3 direct dependencies are installed as runtime dependencies, however, they are not used during test runtime. We moved these dependencies from package.json, and installed the remaining dependencies, the tests all passed.

Would you consider creating a slim version of the package.json, which can help reduce the corresponding maintenance costs and security risks in production?
